### PR TITLE
Detect GitHub pages and serve data accordingly

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6,14 +6,14 @@ var phoibleData;
 /**
  * The location of the data directory
  */
-var dataDir = "/data";
+var dataDir = "/data/";
 
 // Pages hosted through GitHub pages need the repo name as the root directory.
 if (window.location.href.match(/github\.io/)) {
-  dataDir = '/IPA_PROJECT/' + dataDir;
+  dataDir = '/IPA_PROJECT' + dataDir;
 }
 
-const phoibleURI = dataDir + "/phoible-segments-features.tsv";
+const phoibleURI = dataDir + "phoible-segments-features.tsv";
 
 /**
  * Switches the sign of a feature pair

--- a/js/app.js
+++ b/js/app.js
@@ -3,7 +3,17 @@
  */
 var phoibleData;
 
-const phoibleURI = "/IPA_PROJECT/data/phoible-segments-features.tsv";
+/**
+ * The location of the data directory
+ */
+var dataDir = "/data";
+
+// Pages hosted through GitHub pages need the repo name as the root directory.
+if (window.location.href.match(/github\.io/)) {
+  dataDir = '/IPA_PROJECT/' + dataDir;
+}
+
+const phoibleURI = dataDir + "/phoible-segments-features.tsv";
 
 /**
  * Switches the sign of a feature pair


### PR DESCRIPTION
GitHub pages needs the repo name prefixed to the URI when fetching data, but this doesn't work so well elsewhere. This PR makes the app check the domain name so that if it's being served by github.io, it adds the repo name to the request for data. Otherwise, it leaves it off.